### PR TITLE
Feature/open street map consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [PR-38](https://github.com/itk-dev/aapodwalk/pull/38)
+  - Added consent banner (`MapConsentBanner.jsx`)
+  - Updated permission context to include open street map permission
+  - Used localstorage to save yes/no from user 
+  - Added route with extra consent info (`PersonalInformationPolicyPage.jsx`)
 - [PR-37](https://github.com/itk-dev/aapodwalk/pull/37)
   - Update linting
 - [PR-36](https://github.com/itk-dev/aapodwalk/pull/36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR-38](https://github.com/itk-dev/aapodwalk/pull/38)
   - Added consent banner (`MapConsentBanner.jsx`)
   - Updated permission context to include open street map permission
-  - Used localstorage to save yes/no from user 
+  - Used localstorage to save yes/no from user
   - Added route with extra consent info (`PersonalInformationPolicyPage.jsx`)
 - [PR-37](https://github.com/itk-dev/aapodwalk/pull/37)
   - Update linting

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,7 +135,7 @@ function App() {
                   <Route path="tag/:id" element={<TagPage />} />
                   <Route path="route/:id" element={<RoutePage />} />
                   <Route path="info" element={<Info geolocationAvailable={geolocationAvailable} />} />
-                  <Route path="/personal-information-policy" element={<PersonalInformationPolicyPage/>} />
+                  <Route path="/personal-information-policy" element={<PersonalInformationPolicyPage />} />
                   <Route path="*" element={<Navigate to="/" />} />
                 </Routes>
               </PermissionContext.Provider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,9 +7,11 @@ import PermissionContext from "./context/permission-context";
 import Info from "./components/info";
 import TagsList from "./components/tags/TagsList";
 import RoutePage from "./components/routes/RoutePage";
+import PersonalInformationPolicyPage from "./components/PersonalInformationPolicyPage";
 
 function App() {
   const [geolocationAvailable, setGeolocationAvailable] = useState();
+  const [openStreetMapConsent, setOpenStreetMapConsent] = useState(null);
   const [lat, setLat] = useState(null);
   const [long, setLong] = useState(null);
   const [heading, setHeading] = useState(null);
@@ -108,18 +110,32 @@ function App() {
     requestPermissions();
   }, []);
 
+  useEffect(() => {
+    const localStorageConsent = localStorage.getItem("data-consent");
+    if (localStorageConsent) {
+      setOpenStreetMapConsent(localStorageConsent === "true");
+    }
+  }, []);
+
   return (
     <>
       {hasAllowedGeolocation && (
         <div className="App h-full min-h-screen w-screen p-3 text-zinc-800 dark:text-white bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
           <LatLongContext.Provider value={contextLatLong}>
             <CacheContext.Provider value={cacheContext}>
-              <PermissionContext.Provider value={geolocationAvailableContext}>
+              <PermissionContext.Provider
+                value={{
+                  geolocationAvailableContext,
+                  openStreetMapConsent,
+                  setOpenStreetMapConsent,
+                }}
+              >
                 <Routes>
                   <Route path="/" element={<TagsList />} />
                   <Route path="tag/:id" element={<TagPage />} />
                   <Route path="route/:id" element={<RoutePage />} />
                   <Route path="info" element={<Info geolocationAvailable={geolocationAvailable} />} />
+                  <Route path="/personal-information-policy" element={<PersonalInformationPolicyPage/>} />
                   <Route path="*" element={<Navigate to="/" />} />
                 </Routes>
               </PermissionContext.Provider>
@@ -127,7 +143,7 @@ function App() {
           </LatLongContext.Provider>
         </div>
       )}
-      {!hasAllowedGeolocation && <h3>Geolokation er krævet</h3>}
+      {!hasAllowedGeolocation && <h1>Geolokation er krævet</h1>}
     </>
   );
 }

--- a/src/components/MapConsentBanner.jsx
+++ b/src/components/MapConsentBanner.jsx
@@ -36,7 +36,7 @@ const MapConsentBanner = () => {
               <div>
                 <div className="flex justify-between">
                   <button
-                    className="p-1 rounded text-zinc-800 bg-zinc-100 float-right mr-1 grow"
+                    className="p-1 rounded bg-emerald-400 dark:bg-emerald-800 float-right mr-1 grow"
                     type="button"
                     onClick={() => updateConsent(true)}
                   >

--- a/src/components/MapConsentBanner.jsx
+++ b/src/components/MapConsentBanner.jsx
@@ -1,0 +1,60 @@
+import { React, useState, useContext } from "react";
+import PermissionContext from "../context/permission-context";
+import { Link } from "react-router-dom";
+
+const MapConsentBanner = () => {
+  const { setOpenStreetMapConsent, openStreetMapConsent } = useContext(PermissionContext);
+
+  function updateConsent(consent) {
+    localStorage.setItem("data-consent", consent);
+    setOpenStreetMapConsent(consent);
+  }
+
+  // If the user already said yes or no, we will not display the consent banner
+  if (openStreetMapConsent === false || openStreetMapConsent === true) return;
+
+  return (
+    <>
+      <div className="fixed left-3 bottom-3 right-3 dark:bg-zinc-600 flex flex-col gap-3 rounded-lg p-3">
+        <div>
+          <h2 className="mb-2 font-bold">Samtykke</h2>
+          <div className="mt-2 flex flex-col">
+            <div className="flex flex-col gap-2 ">
+              <p>
+                Aarhus Kommune ønsker i forbindelse med Podwalk at indhente dit samtykke til, at vi behandler
+                personoplysninger om dig. Podwalk anvender OpenStreetMap som kortløsning og ved brug af denne indsamles
+                brugrens ip. Hvis du vælger ikke at samtykke vil kortet ikke være tilgængelig i Podwalk. Det samtykke,
+                du har givet til behandlingen, kan til enhver tid trækkes tilbage, dog uden at ændrer på lovligheden af
+                den behandling, der allerede måtte være foretaget. Du kan tilbagetrække et afgivet samtykke ved at
+                henvende dig, mundtligt eller skriftligt, til Aarhus Kommune, Kultur- og Borgerservice
+                <a href="mailto:itkdev@mkb.aarhus.dk"> itkdev@mkb.aarhus.dk</a> itkdev@mkb.aarhus.dk og bede om at få samtykket trukket tilbage. Læs mere om, hvordan vi behandler dine
+                personoplysninger.
+              </p>
+              <div className="mt-3">
+                <Link className="underline" to={`/personal-information-policy`}>
+                  Læs mere om, hvordan vi behandler dine personoplysninger.
+                </Link>
+              </div>
+              <button
+                className="p-1 rounded text-zinc-800 bg-zinc-100 float-right my-1"
+                type="button"
+                onClick={() => updateConsent(true)}
+              >
+                Ja
+              </button>
+              <button
+                className="p-1 rounded text-zinc-800 bg-zinc-100 float-right"
+                type="button"
+                onClick={() => updateConsent(false)}
+              >
+                Nej
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MapConsentBanner;

--- a/src/components/MapConsentBanner.jsx
+++ b/src/components/MapConsentBanner.jsx
@@ -17,9 +17,9 @@ const MapConsentBanner = () => {
     <>
       <div className="fixed left-3 bottom-3 right-3 dark:bg-zinc-600 flex flex-col gap-3 rounded-lg p-3">
         <div>
-          <h2 className="mb-2 font-bold">Samtykke</h2>
-          <div className="mt-2 flex flex-col">
-            <div className="flex flex-col gap-2 ">
+          <h2 className="mb-1 font-bold">Samtykke</h2>
+          <div className="mt-1 flex flex-col">
+            <div className="flex flex-col gap-2">
               <p>
                 Aarhus Kommune ønsker i forbindelse med Podwalk at indhente dit samtykke til, at vi behandler
                 personoplysninger om dig. Podwalk anvender OpenStreetMap som kortløsning og ved brug af denne indsamles
@@ -27,28 +27,30 @@ const MapConsentBanner = () => {
                 du har givet til behandlingen, kan til enhver tid trækkes tilbage, dog uden at ændrer på lovligheden af
                 den behandling, der allerede måtte være foretaget. Du kan tilbagetrække et afgivet samtykke ved at
                 henvende dig, mundtligt eller skriftligt, til Aarhus Kommune, Kultur- og Borgerservice
-                <a href="mailto:itkdev@mkb.aarhus.dk"> itkdev@mkb.aarhus.dk</a> itkdev@mkb.aarhus.dk og bede om at få samtykket trukket tilbage. Læs mere om, hvordan vi behandler dine
-                personoplysninger.
+                <a href="mailto:itkdev@mkb.aarhus.dk"> itkdev@mkb.aarhus.dk</a> itkdev@mkb.aarhus.dk og bede om at få
+                samtykket trukket tilbage. Læs mere om, hvordan vi behandler dine personoplysninger.
               </p>
-              <div className="mt-3">
-                <Link className="underline" to={`/personal-information-policy`}>
-                  Læs mere om, hvordan vi behandler dine personoplysninger.
-                </Link>
+              <Link className="underline" to={`/personal-information-policy`}>
+                Læs mere om, hvordan vi behandler dine personoplysninger.
+              </Link>
+              <div>
+                <div className="flex justify-between">
+                  <button
+                    className="p-1 rounded text-zinc-800 bg-zinc-100 float-right mr-1 grow"
+                    type="button"
+                    onClick={() => updateConsent(true)}
+                  >
+                    Ja
+                  </button>
+                  <button
+                    className="p-1 rounded text-zinc-800 bg-zinc-100 float-right ml-1 grow"
+                    type="button"
+                    onClick={() => updateConsent(false)}
+                  >
+                    Nej
+                  </button>
+                </div>
               </div>
-              <button
-                className="p-1 rounded text-zinc-800 bg-zinc-100 float-right my-1"
-                type="button"
-                onClick={() => updateConsent(true)}
-              >
-                Ja
-              </button>
-              <button
-                className="p-1 rounded text-zinc-800 bg-zinc-100 float-right"
-                type="button"
-                onClick={() => updateConsent(false)}
-              >
-                Nej
-              </button>
             </div>
           </div>
         </div>

--- a/src/components/PersonalInformationPolicyPage.jsx
+++ b/src/components/PersonalInformationPolicyPage.jsx
@@ -1,0 +1,53 @@
+import { React } from "react";
+
+const PersonalInformationPolicyPage = ({}) => {
+  return (
+    <>
+      <h1 className="text-2xl font-extrabold">
+        Oplysninger om Aarhus Kommune Kultur og Borgerservices behandling af dine personoplysninger ved anvendelse af
+        Podwalk
+      </h1>
+      <h2 className="font-extrabold mt-5">Hvad er formålet med og reglerne for behandlingen af personoplysningerne?</h2>
+      <p>
+        Vi behandler personoplysningerne til følgende formål: Podwalk anvender OpenStreetMap som kortløsning og ved brug
+        af denne indsamles brugerens ip.
+      </p>
+      <h2 className="font-extrabold mt-5">Hvilke kategorier af personoplysninger behandler vi?</h2>
+      <p>Aarhus Kommune Kultur og Borgerservice behandler følgende kategorier af personoplysninger:</p>
+      <ul>
+        <li>Almindelige personoplysninger: brugerens ip</li>
+      </ul>
+      <h2 className="font-extrabold mt-5">Hvem modtager personoplysningerne? </h2>
+      <p>Ved brug af Podwalk overlader personoplysningerne til følgende modtagere: </p>
+      <p>
+        Kultur og Borgerservices databehandler Open Street Map, der behandler personoplysninger sikkert på vegne af på
+        baggrund af instruks i en lovpligt databehandleraftale. Hvis Kultur og Borgerservice efter en konkret vurdering
+        videregiver oplysninger til en anden selvstændig dataansvarlig, har denne ansvaret for, at du får besked om, at
+        der er indsamlet personoplysninger ved Kultur og Borgerservice. En sådan videregivelse vil kun finde sted i
+        overensstemmelse med lovgivningen, og vil altid kun omfatte nødvendige relevante data. For videregivelser til
+        forskere gælder altid at en eventuel offentliggørelse af undersøgelsens resultat ikke må ske på en sådan måde,
+        at det er muligt at identificere enkeltpersoner.
+      </p>
+      <h2 className="font-extrabold mt-5">Hvordan opbevarer vi personoplysningerne?</h2>
+      Kultur og Borgerservice opbevarer personoplysningerne så længe det er nødvendigt og sagligt for at opfylde de
+      faglige formål, der er angivet under afsnittet om formål. Derudover er Kultur og Borgerservice pålagt at opbevare
+      personoplysningerne, indtil overlevering til arkiv efter arkivlovens regler. Vi kan på nuværende tidspunkt ikke
+      sige, hvor For udvalgte oplysninger gælder dog at oplysningerne gemmes længere end det faglige formål kræver.
+      Oplysninger gemmes i denne længere opbevaring kun til statistiske formål som beskrevet i første afsnit.
+      <h2 className="font-extrabold mt-5">Dine rettigheder</h2>
+      <p>
+        Du har efter databeskyttelsesforordningen en række rettigheder i forhold til vores behandling af
+        personoplysningerne. Du har normalt efter databeskyttelsesforordningen en række rettigheder så som indsigt,
+        indsigelse og berigtigelse. Da denne behandling er en statistisk behandling hjemlet i
+        databeskyttelsesforordningens artikel 6.1.e bortfalder disse rettigheder jf. databeskyttelseslovens §22, stk. 5
+        om begrænsninger i rettigheder ved videnskabelige og statistiske behandlinger. Datatilsynet har udgivet en
+        vejledning om de registreredes rettigheder, som du finder på www.datatilsynet.dk. Hvis du har spørgsmål til
+        Kultur og Borgerservices behandling af dine personoplysninger kan du kontakte Aarhus Kommune, Kultur og
+        Borgerservice,
+        <a href="mailto:itkdev@mkb.aarhus.dk">ITK itkdev@mkb.aarhus.dk</a>
+      </p>
+    </>
+  );
+};
+
+export default PersonalInformationPolicyPage;

--- a/src/components/map/MapWrapper.jsx
+++ b/src/components/map/MapWrapper.jsx
@@ -1,10 +1,14 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import Xmark from "../../icons/xmark-solid.svg?url";
 import Map from "./Map";
 import "./map-wrapper.css";
+import PermissionContext from "../../context/permission-context";
 
-function MapWrapper({ mapData, goToView, hideMapOverlay }) {
+function MapWrapper({ mapData }) {
   const [focusOnMap, setFocusOnMap] = useState(false);
+  const { openStreetMapConsent } = useContext(PermissionContext);
+
+  if (!openStreetMapConsent) return null;
 
   return (
     <>

--- a/src/components/points-of-interest/PointOfInterest.jsx
+++ b/src/components/points-of-interest/PointOfInterest.jsx
@@ -21,7 +21,7 @@ function PointOfInterest({
   const [proximity, setProximity] = useState(null);
   const [viewSubtitles, setViewSubtitles] = useState(false);
   const [unlocked, setUnlocked] = useState(false);
-  const { geolocationAvailable } = useContext(PermissionContext);
+  const { geolocationAvailableContext: geolocationAvailable } = useContext(PermissionContext);
 
   useEffect(() => {
     if (latitude && longitude && lat && long && geolocationAvailable !== "denied") {

--- a/src/components/routes/RoutePage.jsx
+++ b/src/components/routes/RoutePage.jsx
@@ -32,7 +32,7 @@ function RoutePage() {
   const [source, setSource] = useState(null);
   const [accuracy, setAccuracy] = useState(0);
   const { userLatitude, userLongitude } = useContext(LatLongContext);
-  const { geolocationAvailable } = useContext(PermissionContext);
+  const { geolocationAvailableContext: geolocationAvailable } = useContext(PermissionContext);
   const audioRef = useRef();
   const { fileUrl } = useContext(ApiEndpointContext);
   const isIOS = navigator.userAgent.match(/(iPod|iPhone|iPad)/) && navigator.userAgent.match(/AppleWebKit/);

--- a/src/components/tags/TagsList.jsx
+++ b/src/components/tags/TagsList.jsx
@@ -1,12 +1,11 @@
 import { React, useEffect, useState } from "react";
 import useFetch from "../../util/useFetch";
 import Tag from "./Tag";
-import Xmark from "../../icons/xmark-solid.svg";
+import MapConsentBanner from "../MapConsentBanner";
 
 function TagsList() {
   const [tags, setTags] = useState(null);
   const { data } = useFetch(`tags`);
-  const [viewAbout, setViewAbout] = useState(false);
 
   useEffect(() => {
     if (data) {
@@ -23,42 +22,7 @@ function TagsList() {
         <Tag key={name} numberOfRoutes={routes.length} name={name} id={id} />
       ))}
 
-      <div className="fixed left-3 bottom-3 right-3 bg-sky-400 dark:bg-sky-900 flex flex-col gap-3 rounded-lg p-3">
-        {!viewAbout && (
-          <div>
-            <h2 className="mb-2 font-bold">Hvordan fungerer podwalk?</h2>
-            <button
-              className="py-1 px-4 rounded text-zinc-800 bg-zinc-100 flex-auto"
-              type="button"
-              onClick={() => setViewAbout(!viewAbout)}
-            >
-              Se vejledning
-            </button>
-          </div>
-        )}
-        {viewAbout && (
-          <div id="description">
-            <button
-              className="p-1 rounded text-zinc-800 bg-zinc-100 float-right ml-1 mb-1"
-              type="button"
-              aria-label="Luk beskrivelsen"
-              onClick={() => setViewAbout(!viewAbout)}
-            >
-              <img src={Xmark} alt="Tilbage" className="h-6 w-6 text-zinc-800" />
-            </button>
-            <div className="flex flex-col gap-2">
-              <p>Vælg først en kategori på listen herover.</p>
-              <p>Vælg derefter den ønskede rute.</p>
-              <p>Gå hen til første del af ruten og der kan du starte afspilningen.</p>
-              <p>
-                Lyt til vejledningen eller brug navigations pilen i bunden af rute visningen til at komme til næste
-                punkt. Husk at være opmærksom på dine opgivelser.
-              </p>
-              <p>God fornøjelse med din podwalk.</p>
-            </div>
-          </div>
-        )}
-      </div>
+      <MapConsentBanner></MapConsentBanner>
     </div>
   );
 }


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3165

#### Description

- Added consent banner
- Updated permission context to include open street map permission
- Used localstorage to save yes/no from user
- Added route with extra consent info that no-one will ever visit
- Above mentioned route is currently without a back button. This will be implemented in a future pr. 

#### Screenshot of the result

<img width="411" alt="image" src="https://github.com/user-attachments/assets/bcf7ebe8-c669-4fbd-bd5a-8f155cd7ddd2">



<img width="405" alt="image" src="https://github.com/user-attachments/assets/6b850c18-e307-4d2e-bf15-95b41e76aa07">

