### PR TITLE
make consent readable on light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [PR-40](https://github.com/itk-dev/aapodwalk/pull/40)
+  - Default dark mode
+  - Make consent readable when not on dark mode
+
 ## [1.0.4] - 2024-12-05
 
 - [PR-38](https://github.com/itk-dev/aapodwalk/pull/38)

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Podwalk</title>
   </head>
-  <body>
+  <body class="dark">
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/src/components/MapConsentBanner.jsx
+++ b/src/components/MapConsentBanner.jsx
@@ -15,7 +15,7 @@ const MapConsentBanner = () => {
 
   return (
     <>
-      <div className="fixed left-3 bottom-3 right-3 dark:bg-zinc-600 flex flex-col gap-3 rounded-lg p-3">
+      <div className="fixed left-3 bottom-3 right-3 dark:bg-zinc-600 flex flex-col gap-3 rounded-lg p-3 bg-emerald-400">
         <div>
           <h2 className="mb-1 font-bold">Samtykke</h2>
           <div className="mt-1 flex flex-col">
@@ -36,7 +36,7 @@ const MapConsentBanner = () => {
               <div>
                 <div className="flex justify-between">
                   <button
-                    className="p-1 rounded bg-emerald-400 dark:bg-emerald-800 float-right mr-1 grow"
+                    className="p-1 rounded bg-zinc-100 dark:bg-emerald-800 float-right mr-1 grow"
                     type="button"
                     onClick={() => updateConsent(true)}
                   >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
   theme: {
     extend: {},
   },
+  darkMode: 'selector',
   plugins: [
     require('@tailwindcss/line-clamp'),
   ],


### PR DESCRIPTION
#### Link to ticket

🔢 

#### Description

- Dark mode as default
- Make consent readable on light mode

#### Screenshot of the result

<img width="418" alt="image" src="https://github.com/user-attachments/assets/08fbc55c-3c86-4ff9-9852-a12cc7930fe8">

