### PR TITLE
Feature/3175 route and points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [PR-46](https://github.com/itk-dev/aapodwalk/pull/46)
   - Create the actual route page
-  - Create link to list of points 
+  - Create link to list of points
   - Fix squashed and round image -> not it fits and is less round (in `PointList`)
 - [PR-45](https://github.com/itk-dev/aapodwalk/pull/45)
   - Save tag filter in url

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [PR-46](https://github.com/itk-dev/aapodwalk/pull/46)
+  - Create the actual route page
+  - Create link to list of points 
+  - Fix squashed and round image -> not it fits and is less round (in `PointList`)
 - [PR-45](https://github.com/itk-dev/aapodwalk/pull/45)
   - Save tag filter in url
 - [PR-44](https://github.com/itk-dev/aapodwalk/pull/44)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "start": "vite --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview",
-    "eject": "react-scripts eject",
     "lint:js": "eslint --ext .js --ext .jsx ./src",
     "lint:js:fix": "eslint --ext .js --ext .jsx --fix ./src",
     "check-coding-standards": "npm run lint:js",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,7 +67,7 @@ function App() {
         setUserAllowedAccessToGeoLocation(true);
       } else if (state === "prompt") {
         updateLocation();
-        setUserAllowedAccessToGeoLocation(false);
+        setUserAllowedAccessToGeoLocation(true);
       } else if (state === "denied") {
         setUserAllowedAccessToGeoLocation(false);
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,7 +96,7 @@ function App() {
 
   return (
     <>
-      <div className="App flex flex-col h-full pt-32 min-h-screen dark:text-white w-screen pl-3 pr-3 pb-3 text-zinc-800 bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
+      <div className="App flex flex-col h-full pt-24 min-h-screen dark:text-white w-screen pl-3 pr-3 pb-3 text-zinc-800 bg-zinc-100 dark:bg-zinc-800 overflow-hidden">
         <LatLongContext.Provider value={contextLatLong}>
           <PermissionContext.Provider
             value={{

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,7 +67,7 @@ function App() {
         setUserAllowedAccessToGeoLocation(true);
       } else if (state === "prompt") {
         updateLocation();
-        setUserAllowedAccessToGeoLocation(true);
+        setUserAllowedAccessToGeoLocation(false);
       } else if (state === "denied") {
         setUserAllowedAccessToGeoLocation(false);
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import RouteContext from "./context/RouteContext";
 import Info from "./components/info";
 import FrontPage from "./components/FrontPage";
 import RoutePage from "./components/routes/RoutePage";
+import RoutePoints from "./components/routes/RoutePoints";
 import PersonalInformationPolicyPage from "./components/PersonalInformationPolicyPage";
 import Navbar from "./components/Navbar";
 import FAQ from "./components/FAQ";
@@ -118,6 +119,7 @@ function App() {
               <div className="relative grow overflow-hidden">
                 <Routes>
                   <Route path="/" element={<FrontPage />} />
+                  <Route path="/route/:id/points" element={<RoutePoints />} />
                   <Route path="route/:id" element={<RoutePage />} />
                   <Route path="faq" element={<FAQ />} />
                   <Route path="/personal-information-policy" element={<PersonalInformationPolicyPage />} />

--- a/src/components/CloseButton.jsx
+++ b/src/components/CloseButton.jsx
@@ -2,7 +2,7 @@ import { React } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 
-const CloseButton = ({closeOverlay, label = "luk"}) => {
+const CloseButton = ({ closeOverlay, label = "luk" }) => {
   return (
     <button
       className="flex place-content-center items-center dark:bg-emerald-800 dark:text-white text-sm absolute right-3 rounded-full top-3 z-50 w-9 h-9 bg-white"

--- a/src/components/CloseButton.jsx
+++ b/src/components/CloseButton.jsx
@@ -1,0 +1,18 @@
+import { React } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClose } from "@fortawesome/free-solid-svg-icons";
+
+const CloseButton = ({closeOverlay, label = "luk"}) => {
+  return (
+    <button
+      className="flex place-content-center items-center dark:bg-emerald-800 dark:text-white text-sm absolute right-3 rounded-full top-3 z-50 w-9 h-9 bg-white"
+      type="button"
+      onClick={() => closeOverlay()}
+    >
+      <FontAwesomeIcon className="z-50 w-5 h-5" icon={faClose} />
+      <span class="sr-only">{label}</span>
+    </button>
+  );
+};
+
+export default CloseButton;

--- a/src/components/FrontPage.jsx
+++ b/src/components/FrontPage.jsx
@@ -1,7 +1,7 @@
 import { React, useState, useContext, useEffect } from "react";
 import MapConsentBanner from "./MapConsentBanner";
 import LandingPage from "./LandingPage";
-import TagList from "./tags/TagList";
+import TagFilterList from "./tags/TagFilterList";
 import SelectedTagContext from "../context/SelectedTagContext";
 import RouteList from "./routes/RouteList";
 import RouteContext from "../context/RouteContext";
@@ -18,7 +18,7 @@ function FrontPage() {
     <div>
       <LandingPage />
       <SelectedTagContext.Provider value={{ selectedTag, setSelectedTag }}>
-        <TagList />
+        <TagFilterList />
         <RouteList />
       </SelectedTagContext.Provider>
       <MapConsentBanner />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,14 +1,12 @@
-import { React, useContext } from "react";
+import { React } from "react";
 import Logo from "../icons/logo.svg?url";
 import BackButton from "./BackButton";
 import { Link, useLocation } from "react-router-dom";
 import { faQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import RouteContext from "../context/RouteContext";
 
 const Navbar = () => {
   const { pathname } = useLocation();
-  const { selectedRoute } = useContext(RouteContext);
 
   return (
     <div className="fixed top-0 left-0 right-0 p-2 bg-zinc-100 dark:bg-zinc-800 z-50">
@@ -23,7 +21,6 @@ const Navbar = () => {
           <span className="sr-only">FAQ</span>
         </Link>
       </div>
-      {selectedRoute && <h1 className="text-ms font-bold mb-2">{selectedRoute.title}</h1>}
     </div>
   );
 };

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,7 +9,7 @@ const Navbar = () => {
   const { pathname } = useLocation();
 
   return (
-    <div className="fixed top-0 left-0 right-0 p-2 bg-zinc-100 dark:bg-zinc-800 z-50">
+    <div className="fixed top-0 left-0 right-0 p-2 bg-zinc-100 dark:bg-zinc-800 z-40">
       <div className="mb-6 mt-4 flex justify-between">
         {pathname === "/" && <img src={Logo} alt="" className="w-10 h-10" />}
         {pathname !== "/" && <BackButton />}

--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -18,7 +18,7 @@ function Map({ mapData, zoomControl, additionalClass = "" }) {
       />
       {mapData.map(({ latitude, longitude }, index) => (
         <Marker
-          key={index}
+          key={latitude}
           position={[latitude, longitude]}
           icon={L.divIcon({
             html: `

--- a/src/components/map/MapWrapper.jsx
+++ b/src/components/map/MapWrapper.jsx
@@ -1,8 +1,10 @@
 import { useState, useContext } from "react";
 import Xmark from "../../icons/xmark-solid.svg?url";
 import Map from "./Map";
-import "./map-wrapper.css";
 import PermissionContext from "../../context/permission-context";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClose } from "@fortawesome/free-solid-svg-icons";
+import "./map-wrapper.css";
 
 function MapWrapper({ mapData }) {
   const [focusOnMap, setFocusOnMap] = useState(false);
@@ -20,16 +22,16 @@ function MapWrapper({ mapData }) {
         }
         onClick={() => setFocusOnMap(true)}
       >
-        {focusOnMap && <Map zoomControl={true} mapData={mapData}></Map>}
-        {!focusOnMap && <Map zoomControl={false} additionalClass="opacity-55" mapData={mapData}></Map>}
+        {focusOnMap && <Map zoomControl={true} mapData={mapData} />}
+        {!focusOnMap && <Map zoomControl={false} additionalClass="opacity-10" mapData={mapData} />}
       </div>
       {focusOnMap && (
         <button
-          className=" flex place-content-center dark:bg-zinc-800 dark:text-white text-sm absolute right-0 top-0 z-50 w-9 h-9 bg-white"
+          className="flex place-content-center items-center dark:bg-emerald-800 dark:text-white text-sm absolute right-3 rounded-full top-3 z-50 w-9 h-9 bg-white"
           type="button"
           onClick={() => setFocusOnMap(false)}
         >
-          <img src={Xmark} alt="" className="z-50 w-9 h-9" />
+          <FontAwesomeIcon className="z-50 w-5 h-5" icon={faClose} />
           <span class="sr-only">Luk kortvisning</span>
         </button>
       )}

--- a/src/components/map/MapWrapper.jsx
+++ b/src/components/map/MapWrapper.jsx
@@ -1,10 +1,8 @@
 import { useState, useContext } from "react";
-import Xmark from "../../icons/xmark-solid.svg?url";
 import Map from "./Map";
 import PermissionContext from "../../context/permission-context";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClose } from "@fortawesome/free-solid-svg-icons";
 import "./map-wrapper.css";
+import CloseButton from "../CloseButton";
 
 function MapWrapper({ mapData }) {
   const [focusOnMap, setFocusOnMap] = useState(false);
@@ -26,16 +24,7 @@ function MapWrapper({ mapData }) {
         {focusOnMap && <Map zoomControl={true} mapData={mapData} />}
         {!focusOnMap && <Map zoomControl={false} additionalClass="opacity-10" mapData={mapData} />}
       </button>
-      {focusOnMap && (
-        <button
-          className="flex place-content-center items-center dark:bg-emerald-800 dark:text-white text-sm absolute right-3 rounded-full top-3 z-50 w-9 h-9 bg-white"
-          type="button"
-          onClick={() => setFocusOnMap(false)}
-        >
-          <FontAwesomeIcon className="z-50 w-5 h-5" icon={faClose} />
-          <span class="sr-only">Luk kortvisning</span>
-        </button>
-      )}
+      {focusOnMap && <CloseButton closeOverlay={() => setFocusOnMap(false)} label="luk kortvising" />}
     </>
   );
 }

--- a/src/components/map/MapWrapper.jsx
+++ b/src/components/map/MapWrapper.jsx
@@ -14,17 +14,18 @@ function MapWrapper({ mapData }) {
 
   return (
     <>
-      <div
+      <button
+        type="button"
         className={
           focusOnMap
-            ? "map-container absolute left-0 top-0 right-0 z-50 m-0 h-screen"
-            : "map-container absolute left-0 top-0 right-0 z-0 "
+            ? "map-container absolute left-0 top-0 right-0 z-50 h-screen"
+            : "map-container absolute left-0 top-0 right-0 z-0"
         }
         onClick={() => setFocusOnMap(true)}
       >
         {focusOnMap && <Map zoomControl={true} mapData={mapData} />}
         {!focusOnMap && <Map zoomControl={false} additionalClass="opacity-10" mapData={mapData} />}
-      </div>
+      </button>
       {focusOnMap && (
         <button
           className="flex place-content-center items-center dark:bg-emerald-800 dark:text-white text-sm absolute right-3 rounded-full top-3 z-50 w-9 h-9 bg-white"

--- a/src/components/points/DistanceComponent.jsx
+++ b/src/components/points/DistanceComponent.jsx
@@ -38,7 +38,7 @@ function DistanceComponent({ id, latitude, longitude, classes, proximityToUnlock
     }
   }
 
-  return <div className={classes}>{distance} m</div>;
+  return <div className={`${classes} text-emerald-400 dark:text-emerald-800 font-bold text-sm`}>{distance} m</div>;
 }
 
 export default DistanceComponent;

--- a/src/components/points/OrderComponent.jsx
+++ b/src/components/points/OrderComponent.jsx
@@ -1,0 +1,11 @@
+import { React } from "react";
+
+const OrderComponent = ({ order }) => {
+  return (
+    <div className="flex place-content-center rounded text-xl w-6 h-6 bg-black justify-center mb-2 items-center flex dark:bg-emerald-800">
+      {order}
+    </div>
+  );
+};
+
+export default OrderComponent;

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -12,16 +12,7 @@ import PointOverlay from "./PointOverlay";
 import { useSearchParams } from "react-router-dom";
 
 function Point({
-  point: {
-    latitude,
-    longitude,
-    name,
-    image,
-    id,
-    subtitles,
-    proximityToUnlock = 100,
-    mediaEmbedCode,
-  },
+  point: { latitude, longitude, name, image, id, subtitles, proximityToUnlock = 100, mediaEmbedCode },
   order,
 }) {
   const { nextUnlockablePointId, listOfUnlocked } = useContext(RouteContext);

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -42,7 +42,7 @@ function Point({ point: { latitude, longitude, name, image, id, subtitles, proxi
           unlocked ? "" : "opacity-35"
         }`}
       >
-        <Image src={image} className="w-24 h-24 rounded-full grow w-1/4 ml-2 object-cover" />
+        <Image src={image} className="w-24 h-24 rounded grow w-1/4 ml-2 object-cover" />
         <div className="w-3/4 ml-2">
           <div className="flex place-content-center rounded text-xl w-6 h-6 bg-black justify-center mb-2 items-center flex dark:bg-emerald-800">
             {order}

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -61,7 +61,7 @@ function Point({ point: { latitude, longitude, name, image, id, subtitles, proxi
         <>
           <OrientationArrow />
           <DistanceComponent
-            classes="absolute top-1/2 right-5 transform -translate-x-1/2 -translate-y-1/2 dark:text-emerald-600 font-bold"
+            classes="absolute top-1/2 right-5 transform -translate-x-1/2 -translate-y-1/2"
             id={id}
             latitude={latitude}
             longitude={longitude}

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -42,7 +42,7 @@ function Point({ point: { latitude, longitude, name, image, id, subtitles, proxi
           unlocked ? "" : "opacity-35"
         }`}
       >
-        <Image src={image} className="w-24 h-24 rounded-full grow w-1/4 ml-2" />
+        <Image src={image} className="w-24 h-24 rounded-full grow w-1/4 ml-2 object-cover" />
         <div className="w-3/4 ml-2">
           <div className="flex place-content-center rounded text-xl w-6 h-6 bg-black justify-center mb-2 items-center flex dark:bg-emerald-800">
             {order}

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -110,7 +110,7 @@ function Point({
           </>
         )}
       </button>
-      {sanitizedEmbed && (
+      {embed && (
         <div
           className={`${
             overlay

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -7,11 +7,43 @@ import RouteContext from "../../context/RouteContext";
 import Footprints from "../../icons/footprints.svg?url";
 import OrientationArrow from "./OrientationArrow";
 import DistanceComponent from "./DistanceComponent";
+import OrderComponent from "./OrderComponent";
+import PointOverlay from "./PointOverlay";
+import { useSearchParams } from "react-router-dom";
 
-function Point({ point: { latitude, longitude, name, image, id, subtitles, proximityToUnlock = 100 }, order }) {
+function Point({
+  point: {
+    latitude,
+    longitude,
+    name,
+    image,
+    id,
+    subtitles,
+    proximityToUnlock = 100,
+    mediaEmbedCode,
+  },
+  order,
+}) {
   const { nextUnlockablePointId, listOfUnlocked } = useContext(RouteContext);
   const { userAllowedAccessToGeoLocation } = useContext(PermissionContext);
   const [unlocked, setUnlocked] = useState(false);
+  const [overlay, setOverlay] = useState(false);
+  const [embed, setEmbed] = useState(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("point") !== "null") {
+      setOverlay(Number(searchParams.get("point")) === id);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (overlay) {
+      setSearchParams({ point: id });
+      return;
+    }
+    setSearchParams({});
+  }, [overlay]);
 
   useEffect(() => {
     if (listOfUnlocked) {
@@ -35,46 +67,76 @@ function Point({ point: { latitude, longitude, name, image, id, subtitles, proxi
     return (!unlocked && nextUnlockablePointId !== id) || !userAllowedAccessToGeoLocation;
   }
 
+  function playThis() {
+    setEmbed(mediaEmbedCode);
+  }
+
   return (
-    <div className="relative">
-      <div
-        className={`bg-zinc-100 dark:bg-zinc-900 flex flex-row relative h-32 my-2 rounded flex items-center ${
-          unlocked ? "" : "opacity-35"
-        }`}
-      >
-        <Image src={image} className="w-24 h-24 rounded grow w-1/4 ml-2 object-cover" />
-        <div className="w-3/4 ml-2">
-          <div className="flex place-content-center rounded text-xl w-6 h-6 bg-black justify-center mb-2 items-center flex dark:bg-emerald-800">
-            {order}
+    <>
+      <button type="button" onClick={() => playThis()} className="relative text-left">
+        <div
+          className={`bg-zinc-100 dark:bg-zinc-900 flex flex-row relative h-32 my-2 rounded flex items-center ${
+            unlocked ? "" : "opacity-35"
+          }`}
+        >
+          <Image src={image} className="w-24 h-24 rounded grow w-1/4 ml-2 object-cover" />
+          <div className="w-3/4 ml-2">
+            <OrderComponent order={order} />
+            <h2 className="text-xl font-bold">{name}</h2>
+            <div className="line-clamp-2 text-zinc-300 mr-2">{subtitles}</div>
           </div>
-          <h2 className="text-xl font-bold">{name}</h2>
-          <div className="line-clamp-2 text-zinc-300 mr-2">{subtitles}</div>
+          {isLocked() && (
+            <FontAwesomeIcon
+              icon={faLock}
+              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-4xl"
+            />
+          )}
         </div>
-        {isLocked() && (
-          <FontAwesomeIcon
-            icon={faLock}
-            className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-4xl"
-          />
+        {isNextPointToUnlock() && (
+          <>
+            <OrientationArrow />
+            <DistanceComponent
+              classes="absolute top-1/2 right-5 transform -translate-x-1/2 -translate-y-1/2"
+              id={id}
+              latitude={latitude}
+              longitude={longitude}
+              proximityToUnlock={proximityToUnlock}
+            />
+            <img
+              src={Footprints}
+              alt=""
+              className="w-10 h-10 absolute top-1/2 left-12 transform -translate-x-1/2 -translate-y-1/2"
+            />
+          </>
         )}
-      </div>
-      {isNextPointToUnlock() && (
-        <>
-          <OrientationArrow />
-          <DistanceComponent
-            classes="absolute top-1/2 right-5 transform -translate-x-1/2 -translate-y-1/2"
-            id={id}
-            latitude={latitude}
-            longitude={longitude}
-            proximityToUnlock={proximityToUnlock}
-          />
-          <img
-            src={Footprints}
-            alt=""
-            className="w-10 h-10 absolute top-1/2 left-12 transform -translate-x-1/2 -translate-y-1/2"
-          />
-        </>
+      </button>
+      {sanitizedEmbed && (
+        <div
+          className={`${
+            overlay
+              ? "absolute top-0 left-0 right-0 z-50"
+              : "fixed bottom-0 left-0 right-0 bg-zinc-100 dark:bg-zinc-900"
+          }`}
+        >
+          {!overlay && (
+            <div className="p-3 flex justify-between">
+              <h3>{name}</h3>
+              <button
+                className="text-emerald-400 dark:text-emerald-800 font-bold text-sm"
+                type="button"
+                onClick={() => setOverlay(true)}
+              >
+                Se mere
+              </button>
+            </div>
+          )}
+          <div dangerouslySetInnerHTML={{ __html: embed }} />
+        </div>
       )}
-    </div>
+      {overlay && unlocked && (
+        <PointOverlay description={subtitles} closeOverlay={() => setOverlay(false)} title={name} order={order} />
+      )}
+    </>
   );
 }
 

--- a/src/components/points/PointOverlay.jsx
+++ b/src/components/points/PointOverlay.jsx
@@ -3,7 +3,6 @@ import OrderComponent from "./OrderComponent";
 import CloseButton from "../CloseButton";
 
 const PointOverlay = ({ title, order, closeOverlay, description }) => {
-
   return (
     <div className="fixed bottom-0 left-0 right-0 top-0 bg-zinc-100 dark:bg-zinc-900 z-40 rounded m-2 p-4 flex justify-between flex-col">
       <div className="flex align-between">

--- a/src/components/points/PointOverlay.jsx
+++ b/src/components/points/PointOverlay.jsx
@@ -1,0 +1,19 @@
+import { React } from "react";
+import OrderComponent from "./OrderComponent";
+import CloseButton from "../CloseButton";
+
+const PointOverlay = ({ title, order, closeOverlay, description }) => {
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 top-0 bg-zinc-100 dark:bg-zinc-900 z-40 rounded m-2 p-4 flex justify-between flex-col">
+      <div className="flex align-between">
+        <CloseButton closeOverlay={closeOverlay} label="luk punktvisning" />
+        <OrderComponent order={order} />
+        <span className="ml-2">{title}</span>
+      </div>
+      <p className="ml-2">{description}</p>
+    </div>
+  );
+};
+
+export default PointOverlay;

--- a/src/components/points/PointsList.jsx
+++ b/src/components/points/PointsList.jsx
@@ -23,7 +23,7 @@ const PointsList = ({ points }) => {
       }
     }
   }, [listOfUnlocked, points, setNextUnlockablePointId]);
-
+  
   return (
     <>
       <h1 className="text-ms font-bold mb-2">{selectedRoute.title}</h1>

--- a/src/components/points/PointsList.jsx
+++ b/src/components/points/PointsList.jsx
@@ -3,7 +3,7 @@ import Point from "./Point";
 import RouteContext from "../../context/RouteContext";
 
 const PointsList = ({ points }) => {
-  const { listOfUnlocked, setNextUnlockablePointId } = useContext(RouteContext);
+  const { listOfUnlocked, setNextUnlockablePointId, selectedRoute } = useContext(RouteContext);
 
   function getIdFromPoint(point) {
     return point?.id || null;
@@ -26,6 +26,7 @@ const PointsList = ({ points }) => {
 
   return (
     <>
+      <h1 className="text-ms font-bold mb-2">{selectedRoute.title}</h1>
       {[...points].reverse().map((point, index) => (
         <Point point={point} key={point.id} order={points.length - index} />
       ))}

--- a/src/components/points/PointsList.jsx
+++ b/src/components/points/PointsList.jsx
@@ -23,7 +23,7 @@ const PointsList = ({ points }) => {
       }
     }
   }, [listOfUnlocked, points, setNextUnlockablePointId]);
-  
+
   return (
     <>
       <h1 className="text-ms font-bold mb-2">{selectedRoute.title}</h1>

--- a/src/components/routes/Route.jsx
+++ b/src/components/routes/Route.jsx
@@ -4,6 +4,7 @@ import Image from "../Image";
 import PermissionContext from "../../context/permission-context";
 import SelectedRouteContext from "../../context/RouteContext";
 import DistanceComponent from "../points/DistanceComponent";
+import TagList from "../tags/TagList";
 
 function Route({ route }) {
   // The below is to calculate the proximity between user and first point in route
@@ -22,13 +23,11 @@ function Route({ route }) {
       </div>
       <div className="flex flex-col py-3 pl-3 pr-6 overflow-hidden w-full">
         <div className="text-emerald-400 dark:text-emerald-800 font-bold text-sm flex justify-between">
-          {userAllowedAccessToGeoLocation && (
-            <>
-              <div className="truncate w-4/5">
-                {route.tags.map(({ title }) => (
-                  <span key={title}>{title}, </span>
-                ))}
-              </div>
+          <>
+            <div className="truncate w-4/5">
+              <TagList tags={route.tags} />
+            </div>
+            {userAllowedAccessToGeoLocation && (
               <DistanceComponent
                 id={null}
                 latitude={latitude}
@@ -36,8 +35,8 @@ function Route({ route }) {
                 classes="truncate w-1/5 text-right text-sm"
                 proximityToUnlock={null}
               />
-            </>
-          )}
+            )}
+          </>
         </div>
         <h2 className="mb-2 font-bold">{route.name}</h2>
         <div className="text-xs line-clamp-3">{route.description}</div>

--- a/src/components/routes/Route.jsx
+++ b/src/components/routes/Route.jsx
@@ -8,7 +8,7 @@ import TagList from "../tags/TagList";
 
 function Route({ route }) {
   // The below is to calculate the proximity between user and first point in route
-  const { latitude, longitude } = route.pointsOfInterest[0];
+  const { latitude, longitude } = route.points[0];
   const { userAllowedAccessToGeoLocation } = useContext(PermissionContext);
   const { setSelectedRoute } = useContext(SelectedRouteContext);
 

--- a/src/components/routes/RoutePage.jsx
+++ b/src/components/routes/RoutePage.jsx
@@ -1,8 +1,11 @@
 import { React, useEffect, useState, useContext } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import useFetch from "../../util/useFetch";
 import RouteContext from "../../context/RouteContext";
-import PointsList from "../points/PointsList";
+import MapWrapper from "../map/MapWrapper";
+import TagList from "../tags/TagList";
+import { faPlayCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 function RoutePage() {
   const { id } = useParams();
@@ -32,7 +35,46 @@ function RoutePage() {
 
   if (selectedRoute === null) return null;
 
-  return <PointsList points={selectedRoute.pointsOfInterest} />;
+  const { title, tags, pointsOfInterest, totalDuration, distance, description } = selectedRoute;
+
+  return (
+    <>
+      <MapWrapper mapData={pointsOfInterest} />
+      <div className="p-5 absolute left-0 top-0 right-0 bottom-0 flex flex-col justify-between">
+        <div>
+          <TagList classes="z-5 relative text-lg" tags={tags} />
+          <h1 className="text-4xl z-5 font-extrabold z-5 relative word-break">{title}</h1>
+        </div>
+        <div className="flex flex-col items-end">
+          <div className="w-3/5 mb-10 text-end">Tryk på kortet for at undersøge ruten</div>
+          <div className="bg-emerald-400 w-full dark:bg-emerald-800 mb-3 rounded-md p-3 flex z-5 relative">
+            <div>
+              <div className="font-bold">Distance</div>
+              <div className="text-xl">{distance}</div>
+            </div>
+            <div className="ml-6">
+              <div className="font-bold">Dele</div>
+              <div className="text-xl">{pointsOfInterest.length} styk</div>
+            </div>
+            <div className="ml-6">
+              <div className="font-bold">Afspilningstid</div>
+              <div className="text-xl">{totalDuration} minutter</div>
+            </div>
+          </div>
+          <div className="relative z-5 dark:bg-zinc-800 w-full flex flex-col rounded-lg p-3 mb-3 bg-emerald-400">
+            {description}
+          </div>
+          <Link
+            className="flex items-center mr-1 rounded relative px-5 mt-1 h-9 text-center w-max font-bold bg-zinc-200 text-black z-5"
+            to={`/route/${id}/points`}
+          >
+            <FontAwesomeIcon icon={faPlayCircle} className="mr-1" />
+            Start ruten
+          </Link>
+        </div>
+      </div>
+    </>
+  );
 }
 
 export default RoutePage;

--- a/src/components/routes/RoutePage.jsx
+++ b/src/components/routes/RoutePage.jsx
@@ -35,7 +35,7 @@ function RoutePage() {
 
   if (selectedRoute === null) return null;
 
-  const { title, tags, pointsOfInterest, totalDuration, distance, description } = selectedRoute;
+  const { title, tags, points, totalDuration, distance, description } = selectedRoute;
 
   return (
     <>
@@ -53,7 +53,7 @@ function RoutePage() {
             </div>
             <div className="ml-6">
               <div className="font-bold">Dele</div>
-              <div className="text-xl">{pointsOfInterest.length} styk</div>
+              <div className="text-xl">{points.length} styk</div>
             </div>
             <div className="ml-6">
               <div className="font-bold">Afspilningstid</div>
@@ -72,7 +72,7 @@ function RoutePage() {
           </Link>
         </div>
       </div>
-      <MapWrapper mapData={pointsOfInterest} />
+      <MapWrapper mapData={points} />
     </>
   );
 }

--- a/src/components/routes/RoutePage.jsx
+++ b/src/components/routes/RoutePage.jsx
@@ -39,15 +39,14 @@ function RoutePage() {
 
   return (
     <>
-      <MapWrapper mapData={pointsOfInterest} />
       <div className="p-5 absolute left-0 top-0 right-0 bottom-0 flex flex-col justify-between">
         <div>
           <TagList classes="z-5 relative text-lg" tags={tags} />
-          <h1 className="text-4xl z-5 font-extrabold z-5 relative word-break">{title}</h1>
+          <h1 className="text-4xl font-extrabold z-50 relative word-break">{title}</h1>
         </div>
         <div className="flex flex-col items-end">
           <div className="w-3/5 mb-10 text-end">Tryk på kortet for at undersøge ruten</div>
-          <div className="bg-emerald-400 w-full dark:bg-emerald-800 mb-3 rounded-md p-3 flex z-5 relative">
+          <div className="bg-emerald-400 w-full dark:bg-emerald-800 mb-3 rounded-md p-3 flex z-50 relative">
             <div>
               <div className="font-bold">Distance</div>
               <div className="text-xl">{distance}</div>
@@ -61,11 +60,11 @@ function RoutePage() {
               <div className="text-xl">{totalDuration} minutter</div>
             </div>
           </div>
-          <div className="relative z-5 dark:bg-zinc-800 w-full flex flex-col rounded-lg p-3 mb-3 bg-emerald-400">
+          <div className="relative z-50 dark:bg-zinc-800 w-full flex flex-col rounded-lg p-3 mb-3 bg-emerald-400">
             {description}
           </div>
           <Link
-            className="flex items-center mr-1 rounded relative px-5 mt-1 h-9 text-center w-max font-bold bg-zinc-200 text-black z-5"
+            className="flex items-center mr-1 rounded relative px-5 mt-1 h-9 text-center w-max font-bold bg-zinc-200 text-black z-50"
             to={`/route/${id}/points`}
           >
             <FontAwesomeIcon icon={faPlayCircle} className="mr-1" />
@@ -73,6 +72,7 @@ function RoutePage() {
           </Link>
         </div>
       </div>
+      <MapWrapper mapData={pointsOfInterest} />
     </>
   );
 }

--- a/src/components/routes/RoutePoints.jsx
+++ b/src/components/routes/RoutePoints.jsx
@@ -1,0 +1,38 @@
+import { React, useEffect, useState, useContext } from "react";
+import { useParams } from "react-router-dom";
+import useFetch from "../../util/useFetch";
+import RouteContext from "../../context/RouteContext";
+import PointsList from "../points/PointsList";
+
+function RoutePoints() {
+  const { id } = useParams();
+  const { selectedRoute, setSelectedRoute, setListOfUnlocked } = useContext(RouteContext);
+  const [dataFetched, setDataFetched] = useState(false);
+  function isRouteAlreadySet() {
+    return selectedRoute === null && dataFetched;
+  }
+
+  useEffect(() => {
+    const experiencesFromLocalStorage = localStorage.getItem(`unlocked-experiences-${id}`);
+    if (experiencesFromLocalStorage) {
+      // add to existing unlocked steps
+      setListOfUnlocked(JSON.parse(experiencesFromLocalStorage));
+    }
+  }, []);
+
+  // If the selected route is null (if the user enters with a link) we fetch the route with the id from the url
+  const { data: fetchedRoute } = useFetch(isRouteAlreadySet() ? null : `routes/${id}`);
+
+  useEffect(() => {
+    if (fetchedRoute) {
+      setSelectedRoute(fetchedRoute);
+      setDataFetched(true);
+    }
+  }, [fetchedRoute, setSelectedRoute]);
+
+  if (selectedRoute === null) return null;
+
+  return <PointsList points={selectedRoute.pointsOfInterest} />;
+}
+
+export default RoutePoints;

--- a/src/components/tags/TagFilterList.jsx
+++ b/src/components/tags/TagFilterList.jsx
@@ -1,0 +1,32 @@
+import { React, useEffect, useState } from "react";
+import useFetch from "../../util/useFetch";
+import Tag from "./Tag";
+
+const TagFilterList = () => {
+  const [tags, setTags] = useState(null);
+  const { data } = useFetch("tags");
+
+  useEffect(() => {
+    if (data) {
+      setTags(data["hydra:member"]);
+    }
+  }, [data]);
+
+  if (!tags) return null;
+
+  return (
+    <>
+      <fieldset>
+        <legend>Filtrér</legend>
+        <div className="flex flex-wrap">
+          <Tag key="close-to-tag" title="Tæt på denne placering" id={null} />
+          {tags.map(({ title, id }) => (
+            <Tag key={id} title={title} id={id} />
+          ))}
+        </div>
+      </fieldset>
+    </>
+  );
+};
+
+export default TagFilterList;

--- a/src/components/tags/TagList.jsx
+++ b/src/components/tags/TagList.jsx
@@ -1,32 +1,12 @@
 import { React, useEffect, useState } from "react";
-import useFetch from "../../util/useFetch";
-import Tag from "./Tag";
 
-const TagList = () => {
-  const [tags, setTags] = useState(null);
-  const { data } = useFetch(`tags`);
-
+const TagList = ({ tags, classes = "" }) => {
+  const [displayTags, setDisplayTags] = useState("");
   useEffect(() => {
-    if (data) {
-      setTags(data["hydra:member"]);
-    }
-  }, [data]);
+    setDisplayTags(tags.map(({ title }) => title).join(", "));
+  }, []);
 
-  if (!tags) return null;
-
-  return (
-    <>
-      <fieldset>
-        <legend>Filtrér</legend>
-        <div className="flex flex-wrap">
-          <Tag key="close-to-tag" title="Tæt på denne placering" id={null}></Tag>
-          {tags.map(({ title, id }) => (
-            <Tag key={id} title={title} id={id} />
-          ))}
-        </div>
-      </fieldset>
-    </>
-  );
+  return <span className={`text-emerald-400 dark:text-emerald-800 font-bold text-sm ${classes}`}>{displayTags}</span>;
 };
 
 export default TagList;


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=3085#/tickets/showTicket/3175

#### Description

- Create *the actual* route page from the design
- Create link to list of points (`RoutePoints`)
- Fix squashed and round image -> not it fits and is less round
- Remove eject, a leftover from CRA
- Rename `pointsOfInterest` to `points`
- Create point overlay
- Create `OrderComponent`, which is just a green square with a number in
- Create `CloseButton` that closes an overlay
- Rename `TagList` to `TagFilterList`
- Create `TagList` that does not filter, but just returns a string of tags

#### Screenshot of the result

<img width="427" alt="image" src="https://github.com/user-attachments/assets/6f6504b1-0618-44af-955d-dd3a99d935ec">


<img width="429" alt="image" src="https://github.com/user-attachments/assets/3cc7d138-d888-4d41-9d66-0d85af3a3a11">

<img width="443" alt="image" src="https://github.com/user-attachments/assets/565b6b51-7f36-4c1b-b666-66f216fef7c6">

