### PR TITLE
Fix iOS Safari geolocation re-prompting on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix iOS Safari geolocation re-prompting on every page reload (use `watchPosition`, guard `permissions.query`)
 - Security and dependency updates (8 vulnerabilities fixed, ESLint v9, React/Prettier updated)
 
 ## [1.0.8] - 2025-28-01

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,6 @@ function App() {
   const [infoText, setInfoText] = useState("");
   const [lat, setLat] = useState(null);
   const [long, setLong] = useState(null);
-  const locationUpdateInterval = 30000;
 
   const contextLatLong = useMemo(
     () => ({
@@ -37,42 +36,52 @@ function App() {
     [lat, long],
   );
 
-  function handlePermissionInfoBanner() {
-    navigator.permissions.query({ name: "geolocation" }).then((result) => {
-      if (result.state !== "granted") {
-        setInfo(true);
-        setInfoText(
-          <span>
-            Du har ikke accepteret, at vi må få adgang til din lokation. For at denne applikation skal fungere, skal den
-            bruge din lokation. Hvis du vil vide mere om hvordan du giver denne angang, kan du besøge{" "}
-            <Link className="underline" to="/navigation-help">
-              Hjælp til navigation
-            </Link>
-          </span>,
-        );
-      }
-    });
-  }
+  const permissionDeniedBanner = (
+    <span>
+      Du har ikke accepteret, at vi må få adgang til din lokation. For at denne applikation skal fungere, skal den bruge
+      din lokation. Hvis du vil vide mere om hvordan du giver denne adgang, kan du besøge{" "}
+      <Link className="underline" to="/navigation-help">
+        Hjælp til navigation
+      </Link>
+    </span>
+  );
 
   useEffect(() => {
-    handlePermissionInfoBanner();
+    if (navigator.permissions && navigator.permissions.query) {
+      navigator.permissions
+        .query({ name: "geolocation" })
+        .then((result) => {
+          if (result.state === "denied") {
+            setInfo(true);
+            setInfoText(permissionDeniedBanner);
+          }
+        })
+        .catch(() => {});
+    }
   }, []);
 
-  function startLocationPrompter() {
-    setInterval(() => {
-      navigator.geolocation.getCurrentPosition((position) => {
+  useEffect(() => {
+    const watchId = navigator.geolocation.watchPosition(
+      (position) => {
         setLat(position.coords.latitude);
         setLong(position.coords.longitude);
-      });
-    }, locationUpdateInterval);
-  }
+      },
+      (err) => {
+        if (err.code === err.PERMISSION_DENIED) {
+          setInfo(true);
+          setInfoText(permissionDeniedBanner);
+        } else if (err.code === err.POSITION_UNAVAILABLE) {
+          setError(true);
+          setErrorText("Din lokation kunne ikke bestemmes.");
+        } else if (err.code === err.TIMEOUT) {
+          setError(true);
+          setErrorText("Forespørgslen om din lokation tog for lang tid.");
+        }
+      },
+      { enableHighAccuracy: true, timeout: 30000, maximumAge: 10000 },
+    );
 
-  useEffect(() => {
-    navigator.geolocation.getCurrentPosition((position) => {
-      setLat(position.coords.latitude);
-      setLong(position.coords.longitude);
-    });
-    startLocationPrompter();
+    return () => navigator.geolocation.clearWatch(watchId);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

On iOS Safari, users are re-prompted for geolocation permission after every page reload. This is caused by using `getCurrentPosition()` inside a `setInterval()` — each call triggers a fresh permission prompt on iOS Safari. Additionally, `navigator.permissions.query()` is unsupported on iOS Safari, causing the permission banner logic to fail silently.

## Changes

* Replace `getCurrentPosition` + `setInterval` pattern with `watchPosition`, which triggers only one permission prompt and continuously delivers position updates
* Guard `navigator.permissions.query()` with a feature check for iOS Safari compatibility
* Add error callbacks for `PERMISSION_DENIED`, `POSITION_UNAVAILABLE`, and `TIMEOUT`
* Change permission banner condition from `!== "granted"` to `=== "denied"` so the banner doesn't show for the "prompt" state (let `watchPosition` trigger the actual prompt first)
* Fix typo in Danish text: "angang" → "adgang"

## Files Changed

* `src/App.jsx` — Replaced geolocation logic (all changes confined to this file)
* `CHANGELOG.md` — Updated under `[Unreleased]`

## Test Plan

* Verify location updates work in a desktop browser and the map shows the user's position
* On iOS Safari (physical device): grant permission, reload the page, confirm no re-prompt appears
* Test permission denial flow: deny location, verify info banner appears with navigation help link
* Test timeout/unavailable scenarios show appropriate error messages