### PR TITLE
Fix route page scroll overflow and iOS marker rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update build and styling tooling (Tailwind CSS v4, `@vitejs/plugin-react` v5, removed PostCSS/autoprefixer)
 - Fix iOS Safari geolocation re-prompting on every page reload (use `watchPosition`, guard `permissions.query`)
 - Security and dependency updates (8 vulnerabilities fixed, ESLint v9, React/Prettier updated)
+- Fix "you are here" marker not visible on iOS Safari (corrupted SVG)
+- Fix route page content not scrollable when overflowing viewport
 
 ## [1.0.8] - 2025-28-01
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,8 @@ function App() {
   useEffect(() => {
     const watchId = navigator.geolocation.watchPosition(
       (position) => {
+        setInfo(false);
+        setInfoText("");
         setLat(position.coords.latitude);
         setLong(position.coords.longitude);
       },

--- a/src/components/routes/RoutePage.jsx
+++ b/src/components/routes/RoutePage.jsx
@@ -49,7 +49,7 @@ function RoutePage() {
 
   return (
     <>
-      <div className="p-5 absolute left-0 top-0 right-0 bottom-0 flex flex-col justify-between">
+      <div className="p-5 absolute left-0 top-0 right-0 bottom-0 flex flex-col justify-between overflow-y-auto">
         <div>
           <TagList classes="relative text-lg" tags={tags} />
           <h1 className="text-4xl font-extrabold relative word-break">{title}</h1>

--- a/src/icons/you-are-here-icon.svg
+++ b/src/icons/you-are-here-icon.svg
@@ -3,11 +3,6 @@
         g.fade {
             opacity: 0;
             animation: 2s opacity infinite, 2s scale infinite;
-            transform-origin: cente<svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <style>
-        g.fade {
-            opacity: 0;
-            animation: 2s opacity infinite, 2s scale infinite;
             transform-origin: center;
         }
         @keyframes opacity {
@@ -21,29 +16,10 @@
             100% {transform: scale(1)}
         }
     </style>
-    <g filter="url(#filter0_d_2644_466)">
+    <g>
         <circle cx="14.5" cy="14.5" r="8.5" fill="#DC2626"/>
     </g>
-    <g class="fade" filter="url(#filter0_d_2644_466)">
-        <circle cx="14.5" cy="14.5" r="8.5" fill="#DC2626"/>
-    </g>
-</svg>r;
-        }
-        @keyframes opacity {
-            15% {opacity: 0}
-            50% {opacity: .2}
-            100% {opacity: 0}
-        }
-        @keyframes scale {
-            0% {transform: scale(1)}
-            50% {transform: scale(1.5)}
-            100% {transform: scale(1)}
-        }
-    </style>
-    <g filter="url(#filter0_d_2644_466)">
-        <circle cx="14.5" cy="14.5" r="8.5" fill="#DC2626"/>
-    </g>
-    <g class="fade" filter="url(#filter0_d_2644_466)">
+    <g class="fade">
         <circle cx="14.5" cy="14.5" r="8.5" fill="#DC2626"/>
     </g>
 </svg>


### PR DESCRIPTION
## Summary
- **Fix corrupted `you-are-here-icon.svg`**: The SVG had two `<svg>` elements merged together (second pasted mid-word inside the first's `<style>` block), creating invalid markup that iOS Safari refused to render. Replaced with a clean, single SVG. Also removed references to an undefined `filter` (`url(#filter0_d_2644_466)`) that could cause strict browsers to hide elements entirely.
- **Add `overflow-y-auto` to RoutePage**: Allows the route page content to scroll when it overflows the viewport.
- **Clear info banner on successful geolocation**: Resets the info state when `watchPosition` succeeds, so stale geolocation error messages are dismissed.

## Test plan
- [ ] Verify the red pulsing "you are here" dot is visible on iOS Safari when viewing a route
- [ ] Verify the marker still renders and animates on Android Chrome and desktop browsers
- [ ] Verify the route page scrolls correctly when content overflows
- [ ] Verify geolocation info banner clears after location is acquired