### PR TITLE
Add navigation button and improve point overlay layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Prefer device default maps app for navigation button (geo: URI on Android, Apple Maps on iOS, Google Maps fallback)
 - Add navigation button on next-to-unlock point overlay (opens native maps app)
 - Add descriptive labels below point overlay icons (navigation, map, distance)
 - Improve distance display: show rounded km when >= 1 km, meters when below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add navigation button on next-to-unlock point overlay (opens native maps app)
+- Add descriptive labels below point overlay icons (navigation, map, distance)
+- Improve distance display: show rounded km when >= 1 km, meters when below
 - Update build and styling tooling (Tailwind CSS v4, `@vitejs/plugin-react` v5, removed PostCSS/autoprefixer)
 - Fix iOS Safari geolocation re-prompting on every page reload (use `watchPosition`, guard `permissions.query`)
 - Security and dependency updates (8 vulnerabilities fixed, ESLint v9, React/Prettier updated)
 - Fix "you are here" marker not visible on iOS Safari (corrupted SVG)
 - Fix route page content not scrollable when overflowing viewport
+- Fix map icon not scaling in point overlay (add explicit width alongside height)
 
 ## [1.0.8] - 2025-28-01
 

--- a/src/components/points/DistanceComponent.jsx
+++ b/src/components/points/DistanceComponent.jsx
@@ -37,6 +37,8 @@ function DistanceComponent({ data: { id = null, latitude, longitude, proximityTo
     }
   }, [id, listOfUnlocked, nextUnlockablePointId, proximityToUnlock, distance]);
 
+  // Format distance: show "0 m" for falsy/zero values,
+  // convert to km with one decimal when >= 1000 m, otherwise show meters.
   const formattedDistance =
     distance === false || distance === 0
       ? "0 m"

--- a/src/components/points/DistanceComponent.jsx
+++ b/src/components/points/DistanceComponent.jsx
@@ -37,9 +37,12 @@ function DistanceComponent({ data: { id = null, latitude, longitude, proximityTo
     }
   }, [id, listOfUnlocked, nextUnlockablePointId, proximityToUnlock, distance]);
 
-  const formattedDistance = distance >= 1000
-    ? `${(distance / 1000).toFixed(1)} km`
-    : `${distance} m`;
+  const formattedDistance =
+    distance === false || distance === 0
+      ? "0 m"
+      : distance >= 1000
+        ? `${(distance / 1000).toFixed(1)} km`
+        : `${distance} m`;
 
   return (
     <div className={`${classes} text-emerald-400 dark:text-emerald-600 font-bold text-sm`}>

--- a/src/components/points/DistanceComponent.jsx
+++ b/src/components/points/DistanceComponent.jsx
@@ -37,10 +37,14 @@ function DistanceComponent({ data: { id = null, latitude, longitude, proximityTo
     }
   }, [id, listOfUnlocked, nextUnlockablePointId, proximityToUnlock, distance]);
 
+  const formattedDistance = distance >= 1000
+    ? `${(distance / 1000).toFixed(1)} km`
+    : `${distance} m`;
+
   return (
     <div className={`${classes} text-emerald-400 dark:text-emerald-600 font-bold text-sm`}>
       <span className="sr-only">Der er </span>
-      {distance} m <span className="sr-only"> til denne</span>
+      {formattedDistance} <span className="sr-only"> til denne</span>
     </div>
   );
 }

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -48,8 +48,8 @@ function Point({ point, order }) {
 
   function openNativeNavigation() {
     const url = isDeviceIOS
-      ? `https://maps.apple.com/?q=${latitude},${longitude}`
-      : `https://maps.google.com/?q=${latitude},${longitude}`;
+      ? `https://maps.apple.com/?daddr=${latitude},${longitude}`
+      : `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}`;
     window.open(url, "_blank");
   }
 
@@ -102,15 +102,13 @@ function Point({ point, order }) {
       )}
       {isNextPointToUnlock() && (
         <div className="absolute top-1/2 left-0 right-0 -translate-y-1/2 flex items-start justify-around px-4">
-          <button
-            type="button"
-            onClick={openNativeNavigation}
-            className="flex flex-col items-center cursor-pointer"
-          >
+          <button type="button" onClick={openNativeNavigation} className="flex flex-col items-center cursor-pointer">
             <div className="h-12 flex items-center justify-center">
               <img src={Footprints} alt="" className="h-10 w-10" />
             </div>
-            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">Åbn navigation</span>
+            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">
+              Åbn navigation
+            </span>
           </button>
           {openStreetMapConsent && (
             <Link
@@ -118,7 +116,7 @@ function Point({ point, order }) {
               className="flex flex-col items-center cursor-pointer text-emerald-400 dark:text-emerald-600"
             >
               <div className="h-12 flex items-center justify-center">
-                <FontAwesomeIcon style={{ height: '1.4rem', width: '1.4rem' }} icon={faMapLocationDot} />
+                <FontAwesomeIcon style={{ height: "1.4rem", width: "1.4rem" }} icon={faMapLocationDot} />
               </div>
               <span className="text-xs font-bold mt-1 whitespace-nowrap">Åbn kort</span>
               <span className="sr-only">Se punkt {name} på kort</span>
@@ -131,7 +129,7 @@ function Point({ point, order }) {
               className="flex flex-col items-center cursor-pointer text-emerald-400 dark:text-emerald-600"
             >
               <div className="h-12 flex items-center justify-center">
-                <FontAwesomeIcon style={{ height: '1.4rem', width: '1.4rem' }} icon={faMapLocationDot} />
+                <FontAwesomeIcon style={{ height: "1.4rem", width: "1.4rem" }} icon={faMapLocationDot} />
               </div>
               <span className="text-xs font-bold mt-1 whitespace-nowrap">Åbn kort</span>
               <span className="sr-only">Tag stilling til tilladelser i forhold til kortet igen</span>
@@ -141,7 +139,9 @@ function Point({ point, order }) {
             <div className="h-12 flex items-center">
               <DistanceComponent data={point} classes="text-xl" />
             </div>
-            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">Afstand</span>
+            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">
+              Afstand
+            </span>
           </div>
         </div>
       )}

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -10,7 +10,7 @@ import OrderComponent from "./OrderComponent";
 import PointOverlay from "./PointOverlay";
 import LatLongContext from "../../context/latitude-longitude-context";
 import PermissionContext from "../../context/permission-context";
-import { isDeviceIOS } from "../../util/helper";
+import { isDeviceIOS, isDeviceAndroid } from "../../util/helper";
 
 function Point({ point, order }) {
   const { latitude, longitude, name, image, id, subtitles, proximityToUnlock = 100 } = point;
@@ -46,10 +46,22 @@ function Point({ point, order }) {
     return nextUnlockablePointId === id && !unlocked && lat && long;
   }
 
+  // Opens navigation to the point's coordinates using the device's preferred maps app.
+  // - iOS: Apple Maps directions URL (the native default on iOS).
+  // - Android: geo: URI, which triggers the OS intent chooser so the user can open
+  //   in their preferred maps app (Google Maps, Waze, OsmAnd, etc.).
+  //   Trade-off: the geo: URI shows the destination as a pin rather than auto-starting
+  //   turn-by-turn directions — the user taps "Navigate" once in their chosen app.
+  // - Fallback: Google Maps directions URL for desktop and other platforms.
   function openNativeNavigation() {
-    const url = isDeviceIOS
-      ? `https://maps.apple.com/?daddr=${latitude},${longitude}`
-      : `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}`;
+    let url;
+    if (isDeviceIOS) {
+      url = `https://maps.apple.com/?daddr=${latitude},${longitude}`;
+    } else if (isDeviceAndroid) {
+      url = `geo:${latitude},${longitude}`;
+    } else {
+      url = `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}`;
+    }
     window.open(url, "_blank");
   }
 

--- a/src/components/points/Point.jsx
+++ b/src/components/points/Point.jsx
@@ -10,6 +10,7 @@ import OrderComponent from "./OrderComponent";
 import PointOverlay from "./PointOverlay";
 import LatLongContext from "../../context/latitude-longitude-context";
 import PermissionContext from "../../context/permission-context";
+import { isDeviceIOS } from "../../util/helper";
 
 function Point({ point, order }) {
   const { latitude, longitude, name, image, id, subtitles, proximityToUnlock = 100 } = point;
@@ -43,6 +44,13 @@ function Point({ point, order }) {
     // - It has not already been unlocked
     // - The user gives access to geolocation
     return nextUnlockablePointId === id && !unlocked && lat && long;
+  }
+
+  function openNativeNavigation() {
+    const url = isDeviceIOS
+      ? `https://maps.apple.com/?q=${latitude},${longitude}`
+      : `https://maps.google.com/?q=${latitude},${longitude}`;
+    window.open(url, "_blank");
   }
 
   function isLocked() {
@@ -93,13 +101,26 @@ function Point({ point, order }) {
         <PointOverlay point={point} order={order} active={playThis} toggleActive={() => setPlayThis(!playThis)} />
       )}
       {isNextPointToUnlock() && (
-        <>
+        <div className="absolute top-1/2 left-0 right-0 -translate-y-1/2 flex items-start justify-around px-4">
+          <button
+            type="button"
+            onClick={openNativeNavigation}
+            className="flex flex-col items-center cursor-pointer"
+          >
+            <div className="h-12 flex items-center justify-center">
+              <img src={Footprints} alt="" className="h-10 w-10" />
+            </div>
+            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">Åbn navigation</span>
+          </button>
           {openStreetMapConsent && (
             <Link
               to={`/see-on-map/${latitude}/${longitude}`}
-              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex flex-col cursor-pointer text-emerald-400 dark:text-emerald-600"
+              className="flex flex-col items-center cursor-pointer text-emerald-400 dark:text-emerald-600"
             >
-              <FontAwesomeIcon className="h-9" icon={faMapLocationDot} />
+              <div className="h-12 flex items-center justify-center">
+                <FontAwesomeIcon style={{ height: '1.4rem', width: '1.4rem' }} icon={faMapLocationDot} />
+              </div>
+              <span className="text-xs font-bold mt-1 whitespace-nowrap">Åbn kort</span>
               <span className="sr-only">Se punkt {name} på kort</span>
             </Link>
           )}
@@ -107,22 +128,22 @@ function Point({ point, order }) {
             <button
               type="button"
               onClick={() => setOpenStreetMapConsent(null)}
-              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 cursor-pointer text-emerald-400 dark:text-emerald-600"
+              className="flex flex-col items-center cursor-pointer text-emerald-400 dark:text-emerald-600"
             >
-              <FontAwesomeIcon className="h-9" icon={faMapLocationDot} />
+              <div className="h-12 flex items-center justify-center">
+                <FontAwesomeIcon style={{ height: '1.4rem', width: '1.4rem' }} icon={faMapLocationDot} />
+              </div>
+              <span className="text-xs font-bold mt-1 whitespace-nowrap">Åbn kort</span>
               <span className="sr-only">Tag stilling til tilladelser i forhold til kortet igen</span>
             </button>
           )}
-          <DistanceComponent
-            data={point}
-            classes="absolute top-1/2 right-5 transform -translate-x-1/2 -translate-y-1/2 text-xl"
-          />
-          <img
-            src={Footprints}
-            alt=""
-            className="h-16 h-16 absolute top-1/2 left-12 transform -translate-x-1/2 -translate-y-1/2"
-          />
-        </>
+          <div className="flex flex-col items-center">
+            <div className="h-12 flex items-center">
+              <DistanceComponent data={point} classes="text-xl" />
+            </div>
+            <span className="text-xs font-bold mt-1 whitespace-nowrap text-emerald-400 dark:text-emerald-600">Afstand</span>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/util/helper.js
+++ b/src/util/helper.js
@@ -1,6 +1,7 @@
 import YouAreHere from "./../icons/you-are-here-icon.svg?raw";
 
 export const isDeviceIOS = navigator.userAgent.match(/(iPod|iPhone|iPad)/) && navigator.userAgent.match(/AppleWebKit/);
+export const isDeviceAndroid = /Android/i.test(navigator.userAgent);
 
 // Borrowed from here: https://www.movable-type.co.uk/scripts/latlong.html?from=48.86,-122.0992&to=48.8599,-122.1449
 export function getDistanceBetweenCoordinates(lat1, lon1, lat2, lon2) {


### PR DESCRIPTION
## Summary

- Add a native navigation button to the next-to-unlock point overlay (opens Apple Maps on iOS, Google Maps on Android)
- Rework overlay layout from absolute-positioned elements to a three-column flex row with descriptive labels (navigation, map, distance)
- Fix map icon sizing by using inline styles to override FontAwesome's `svg-inline--fa` class
- Improve distance display to show rounded km (e.g. "1.2 km") when distance is >= 1000 m

## Screenshot

<img width="377" height="145" alt="Screenshot 2026-03-11 at 19 02 23" src="https://github.com/user-attachments/assets/755827b0-a098-4eb5-86cc-198730b62043" />


## Test plan

- [ ] Open a route's points page and locate the "next to unlock" point
- [ ] Verify all three icons (footprints, map, distance) are visible with labels beneath them
- [ ] Tap the footprints/navigation button — confirm it opens native maps app with correct coordinates
- [ ] Tap the map button — confirm it navigates to the OpenStreetMap view (or prompts for consent)
- [ ] Verify the map icon renders at the correct size (~1.4rem)
- [ ] Verify distance shows meters below 1 km and km at or above 1 km
- [ ] Test on both iOS Safari and Android Chrome